### PR TITLE
Potential fix for code scanning alert no. 1267: Inconsistent compareTo

### DIFF
--- a/src/main/java/com/justjournal/model/Mood.java
+++ b/src/main/java/com/justjournal/model/Mood.java
@@ -94,4 +94,21 @@ public class Mood implements Serializable, Comparable<Mood> {
   public int compareTo(Mood mood) {
     return this.getTitle().compareTo(mood.getTitle());
   }
+
+  @Override
+  public boolean equals(Object obj) {
+    if (this == obj) {
+      return true;
+    }
+    if (obj == null || getClass() != obj.getClass()) {
+      return false;
+    }
+    Mood mood = (Mood) obj;
+    return title.equals(mood.title);
+  }
+
+  @Override
+  public int hashCode() {
+    return title.hashCode();
+  }
 }


### PR DESCRIPTION
Potential fix for [https://github.com/JustJournal/justjournal/security/code-scanning/1267](https://github.com/JustJournal/justjournal/security/code-scanning/1267)

To fix the problem, we need to override the `equals` method in the `Mood` class to ensure it is consistent with the `compareTo` method. The `equals` method should compare the `title` fields of the `Mood` objects to determine equality. Additionally, we should override the `hashCode` method to maintain the general contract for the `hashCode` method, which states that equal objects must have equal hash codes.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

## Summary by Sourcery

Bug Fixes:
- Fix potential inconsistency in object comparison by implementing equals and hashCode methods that use the title field for comparison